### PR TITLE
Remove transaction only when max retries are reached

### DIFF
--- a/core/transaction.c
+++ b/core/transaction.c
@@ -411,7 +411,7 @@ int transaction_send(lwm2m_context_t * contextP,
         }
     }
 
-    if (transacP->ack_received || maxRetriesReached)
+    if (maxRetriesReached)
     {
         if (transacP->callback)
         {


### PR DESCRIPTION
I removed ```transacP->ack_received``` checking, because if observe cancellation is requested, sometimes two messages are detected, calling ```free()``` two times (which causes segmentation fault).
To reproduce this problem:

1. Connect sensor(-s) to restserver.
2. ```PUT``` request to ```/subscriptions/<connected-sensor-UUID>/<path-to-resource>``` (must be a valid, observable resource).
3. ```DELETE``` request to ```/subscriptions/<connected-sensor-UUID>/<path-to-resource>``` (observation must be started already).

If problem doesn't occur, repeat last two steps until it does.

_**Note:** You can reproduce the problem only if observation removal is implemented._