### PR TITLE
restserver: lock rest context

### DIFF
--- a/examples/rest-server/rest-core.c
+++ b/examples/rest-server/rest-core.c
@@ -24,6 +24,7 @@
 
 #include "restserver.h"
 
+#include <assert.h>
 #include <string.h>
 
 
@@ -38,6 +39,8 @@ void rest_init(rest_context_t *rest)
     rest->asyncResponseList = rest_list_new();
     rest->pendingResponseList = rest_list_new();
     rest->observeList = rest_list_new();
+
+    assert(pthread_mutex_init(&rest->mutex, NULL) == 0);
 }
 
 int rest_step(rest_context_t *rest, struct timeval *tv)
@@ -76,5 +79,15 @@ int rest_step(rest_context_t *rest, struct timeval *tv)
     }
 
     return 0;
+}
+
+void rest_lock(rest_context_t *rest)
+{
+    assert(pthread_mutex_lock(&rest->mutex) == 0);
+}
+
+void rest_unlock(rest_context_t *rest)
+{
+    assert(pthread_mutex_unlock(&rest->mutex) == 0);
 }
 

--- a/examples/rest-server/rest-endpoints.c
+++ b/examples/rest-server/rest-endpoints.c
@@ -112,6 +112,8 @@ int rest_endpoints_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *contex
     rest_context_t *rest = (rest_context_t *)context;
     lwm2m_client_t *client;
 
+    rest_lock(rest);
+
     json_t *jclients = json_array();
     for (client = rest->lwm2m->clientList; client != NULL; client = client->next)
     {
@@ -120,6 +122,9 @@ int rest_endpoints_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *contex
 
     ulfius_set_json_body_response(resp, 200, jclients);
     json_decref(jclients);
+
+    rest_unlock(rest);
+
     return U_CALLBACK_CONTINUE;
 }
 
@@ -130,16 +135,23 @@ int rest_endpoints_name_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *c
     const char *name = u_map_get(req->map_url, "name");
     json_t *jclient;
 
+    rest_lock(rest);
+
     client = rest_endpoints_find_client(rest->lwm2m->clientList, name);
+
     if (client == NULL)
     {
         ulfius_set_empty_body_response(resp, 404);
-        return U_CALLBACK_COMPLETE;
+    }
+    else
+    {
+        jclient = endpoint_resources_to_json(client);
+        ulfius_set_json_body_response(resp, 200, jclient);
+        json_decref(jclient);
     }
 
-    jclient = endpoint_resources_to_json(client);
-    ulfius_set_json_body_response(resp, 200, jclient);
-    json_decref(jclient);
-    return U_CALLBACK_COMPLETE;
+    rest_unlock(rest);
+
+    return U_CALLBACK_CONTINUE;
 }
 

--- a/examples/rest-server/rest-endpoints.c
+++ b/examples/rest-server/rest-endpoints.c
@@ -125,7 +125,7 @@ int rest_endpoints_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *contex
 
     rest_unlock(rest);
 
-    return U_CALLBACK_CONTINUE;
+    return U_CALLBACK_COMPLETE;
 }
 
 int rest_endpoints_name_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *context)
@@ -152,6 +152,6 @@ int rest_endpoints_name_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *c
 
     rest_unlock(rest);
 
-    return U_CALLBACK_CONTINUE;
+    return U_CALLBACK_COMPLETE;
 }
 

--- a/examples/rest-server/rest-notifications.c
+++ b/examples/rest-server/rest-notifications.c
@@ -82,15 +82,18 @@ int rest_notifications_get_callback_cb(const ulfius_req_t *req, ulfius_resp_t *r
 {
     rest_context_t *rest = (rest_context_t *)context;
 
+    rest_lock(rest);
+
     if (rest->callback == NULL)
     {
         ulfius_set_empty_body_response(resp, 404);
-        return U_CALLBACK_CONTINUE;
     }
     else
     {
         ulfius_set_json_body_response(resp, 200, rest->callback);
     }
+
+    rest_unlock(rest);
 
     return U_CALLBACK_CONTINUE;
 }
@@ -118,6 +121,8 @@ int rest_notifications_put_callback_cb(const ulfius_req_t *req, ulfius_resp_t *r
 
     fprintf(stdout, "[SET-CALLBACK] url=%s\n", json_string_value(json_object_get(jcallback, "url")));
 
+    rest_lock(rest);
+
     if (rest->callback != NULL)
     {
         json_decref(rest->callback);
@@ -126,6 +131,8 @@ int rest_notifications_put_callback_cb(const ulfius_req_t *req, ulfius_resp_t *r
 
     rest->callback = jcallback;
 
+    rest_unlock(rest);
+
     return U_CALLBACK_CONTINUE;
 }
 
@@ -133,12 +140,16 @@ int rest_notifications_pull_cb(const ulfius_req_t *req, ulfius_resp_t *resp, voi
 {
     rest_context_t *rest = (rest_context_t *)context;
 
+    rest_lock(rest);
+
     json_t *jbody = rest_notifications_json(rest);
 
     rest_notifications_clear(rest);
 
     ulfius_set_json_body_response(resp, 200, jbody);
     json_decref(jbody);
+
+    rest_unlock(rest);
 
     return U_CALLBACK_CONTINUE;
 }

--- a/examples/rest-server/rest-notifications.c
+++ b/examples/rest-server/rest-notifications.c
@@ -95,7 +95,7 @@ int rest_notifications_get_callback_cb(const ulfius_req_t *req, ulfius_resp_t *r
 
     rest_unlock(rest);
 
-    return U_CALLBACK_CONTINUE;
+    return U_CALLBACK_COMPLETE;
 }
 
 int rest_notifications_put_callback_cb(const ulfius_req_t *req, ulfius_resp_t *resp,
@@ -109,14 +109,14 @@ int rest_notifications_put_callback_cb(const ulfius_req_t *req, ulfius_resp_t *r
     if (ct == NULL || strcmp(ct, "application/json") != 0)
     {
         ulfius_set_empty_body_response(resp, 415);
-        return U_CALLBACK_CONTINUE;
+        return U_CALLBACK_COMPLETE;
     }
 
     jcallback = json_loadb(req->binary_body, req->binary_body_length, 0, NULL);
     if (!validate_callback(jcallback))
     {
         ulfius_set_empty_body_response(resp, 400);
-        return U_CALLBACK_CONTINUE;
+        return U_CALLBACK_COMPLETE;
     }
 
     fprintf(stdout, "[SET-CALLBACK] url=%s\n", json_string_value(json_object_get(jcallback, "url")));
@@ -133,7 +133,7 @@ int rest_notifications_put_callback_cb(const ulfius_req_t *req, ulfius_resp_t *r
 
     rest_unlock(rest);
 
-    return U_CALLBACK_CONTINUE;
+    return U_CALLBACK_COMPLETE;
 }
 
 int rest_notifications_pull_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *context)
@@ -151,7 +151,7 @@ int rest_notifications_pull_cb(const ulfius_req_t *req, ulfius_resp_t *resp, voi
 
     rest_unlock(rest);
 
-    return U_CALLBACK_CONTINUE;
+    return U_CALLBACK_COMPLETE;
 }
 
 void rest_notify_registration(rest_context_t *rest, rest_notif_registration_t *reg)

--- a/examples/rest-server/rest-resources.c
+++ b/examples/rest-server/rest-resources.c
@@ -123,7 +123,7 @@ int rest_resources_rwe_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *co
     else
     {
         ulfius_set_empty_body_response(resp, 405);
-        return U_CALLBACK_CONTINUE;
+        return U_CALLBACK_COMPLETE;
     }
 
     if ((action == RES_ACTION_WRITE) || (action == RES_ACTION_EXEC))
@@ -132,7 +132,7 @@ int rest_resources_rwe_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *co
         if (format == -1)
         {
             ulfius_set_empty_body_response(resp, 415);
-            return U_CALLBACK_CONTINUE;
+            return U_CALLBACK_COMPLETE;
         }
     }
 
@@ -144,7 +144,7 @@ int rest_resources_rwe_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *co
     if (client == NULL)
     {
         ulfius_set_empty_body_response(resp, 410);
-        return U_CALLBACK_CONTINUE;
+        return U_CALLBACK_COMPLETE;
     }
 
     /* Reconstruct and validate client path */
@@ -160,7 +160,7 @@ int rest_resources_rwe_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *co
     if (strncmp(path, req->http_url, len) != 0)
     {
         ulfius_set_empty_body_response(resp, 404);
-        return U_CALLBACK_CONTINUE;
+        return U_CALLBACK_COMPLETE;
     }
 
     /* Extract and convert resource path */
@@ -169,7 +169,7 @@ int rest_resources_rwe_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *co
     if (lwm2m_stringToUri(path, strlen(path), &uri) == 0)
     {
         ulfius_set_empty_body_response(resp, 404);
-        return U_CALLBACK_CONTINUE;
+        return U_CALLBACK_COMPLETE;
     }
 
     /*
@@ -280,7 +280,7 @@ int rest_resources_rwe_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *co
 
     rest_unlock(rest);
 
-    return U_CALLBACK_CONTINUE;
+    return U_CALLBACK_COMPLETE;
 
 exit:
     if (err == U_CALLBACK_ERROR)

--- a/examples/rest-server/rest-subscriptions.c
+++ b/examples/rest-server/rest-subscriptions.c
@@ -80,7 +80,9 @@ int rest_subscriptions_put_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void
 
     /* Find requested client */
     name = u_map_get(req->map_url, "name");
+    rest_lock(rest);
     client = rest_endpoints_find_client(rest->lwm2m->clientList, name);
+    rest_unlock(rest);
     if (client == NULL)
     {
         ulfius_set_empty_body_response(resp, 404);
@@ -117,6 +119,15 @@ int rest_subscriptions_put_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void
      * go through the cleanup section. See comment above.
      */
     const int err = U_CALLBACK_ERROR;
+
+    rest_lock(rest);
+
+    // Duplicate check just in case client was removed while rest was unlocked
+    client = rest_endpoints_find_client(rest->lwm2m->clientList, name);
+    if (client == NULL)
+    {
+        goto exit;
+    }
 
     // Search for existing registrations to prevent duplicates
     for (targetP = client->observationList; targetP != NULL; targetP = targetP->next)
@@ -164,6 +175,8 @@ int rest_subscriptions_put_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void
     ulfius_set_json_body_response(resp, 202, jresponse);
     json_decref(jresponse);
 
+    rest_unlock(rest);
+
     return U_CALLBACK_CONTINUE;
 
 exit:
@@ -178,6 +191,8 @@ exit:
             free(observe_context);
         }
     }
+
+    rest_unlock(rest);
 
     return err;
 }

--- a/examples/rest-server/rest-subscriptions.c
+++ b/examples/rest-server/rest-subscriptions.c
@@ -86,7 +86,7 @@ int rest_subscriptions_put_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void
     if (client == NULL)
     {
         ulfius_set_empty_body_response(resp, 404);
-        return U_CALLBACK_CONTINUE;
+        return U_CALLBACK_COMPLETE;
     }
 
     /* Reconstruct and validate client path */
@@ -102,7 +102,7 @@ int rest_subscriptions_put_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void
     if (strncmp(path, req->http_url, len) != 0)
     {
         ulfius_set_empty_body_response(resp, 404);
-        return U_CALLBACK_CONTINUE;
+        return U_CALLBACK_COMPLETE;
     }
 
     /* Extract and convert resource path */
@@ -111,7 +111,7 @@ int rest_subscriptions_put_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void
     if (lwm2m_stringToUri(path, strlen(path), &uri) == 0)
     {
         ulfius_set_empty_body_response(resp, 404);
-        return U_CALLBACK_CONTINUE;
+        return U_CALLBACK_COMPLETE;
     }
 
     /*
@@ -177,7 +177,7 @@ int rest_subscriptions_put_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void
 
     rest_unlock(rest);
 
-    return U_CALLBACK_CONTINUE;
+    return U_CALLBACK_COMPLETE;
 
 exit:
     if (err == U_CALLBACK_ERROR)

--- a/examples/rest-server/restserver.c
+++ b/examples/rest-server/restserver.c
@@ -263,6 +263,7 @@ int main(int argc, char *argv[])
         tv.tv_sec = 5;
         tv.tv_usec = 0;
 
+        rest_lock(&rest);
         res = lwm2m_step(rest.lwm2m, &tv.tv_sec);
         if (res)
         {
@@ -274,6 +275,7 @@ int main(int argc, char *argv[])
         {
             fprintf(stderr, "rest_step() error: %d\n", res);
         }
+        rest_unlock(&rest);
 
         res = select(FD_SETSIZE, &readfds, NULL, NULL, &tv);
         if (res < 0)
@@ -287,7 +289,9 @@ int main(int argc, char *argv[])
 
         if (FD_ISSET(sock, &readfds))
         {
+            rest_lock(&rest);
             socket_receive(rest.lwm2m, sock);
+            rest_unlock(&rest);
         }
 
     }

--- a/examples/rest-server/restserver.h
+++ b/examples/rest-server/restserver.h
@@ -38,6 +38,8 @@ typedef struct _u_response ulfius_resp_t;
 
 typedef struct
 {
+    pthread_mutex_t mutex;
+
     lwm2m_context_t *lwm2m;
 
     // rest-core
@@ -85,6 +87,9 @@ int rest_subscriptions_put_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void
 
 void rest_init(rest_context_t *rest);
 int rest_step(rest_context_t *rest, struct timeval *tv);
+
+void rest_lock(rest_context_t *rest);
+void rest_unlock(rest_context_t *rest);
 
 #endif // RESTSERVER_H
 


### PR DESCRIPTION
Ulfius calls each request callback from a new thread. This PR adds mutex to rest context that should prevent  data corruption and the arising segfaults.