### PR TITLE
restserver: fix memory leaks

### DIFF
--- a/examples/rest-server/rest-core.c
+++ b/examples/rest-server/rest-core.c
@@ -49,8 +49,6 @@ void rest_cleanup(rest_context_t *rest)
     rest_list_delete(rest->asyncResponseList);
     rest_list_delete(rest->pendingResponseList);
     rest_list_delete(rest->observeList);
-
-    assert(pthread_mutex_destroy(&rest->mutex) == 0);
 }
 
 int rest_step(rest_context_t *rest, struct timeval *tv)

--- a/examples/rest-server/rest-core.c
+++ b/examples/rest-server/rest-core.c
@@ -40,6 +40,19 @@ void rest_init(rest_context_t *rest)
     rest->observeList = rest_list_new();
 }
 
+void rest_cleanup(rest_context_t *rest)
+{
+    rest_list_delete(rest->registrationList);
+    rest_list_delete(rest->updateList);
+    rest_list_delete(rest->deregistrationList);
+    rest_list_delete(rest->timeoutList);
+    rest_list_delete(rest->asyncResponseList);
+    rest_list_delete(rest->pendingResponseList);
+    rest_list_delete(rest->observeList);
+
+    assert(pthread_mutex_destroy(&rest->mutex) == 0);
+}
+
 int rest_step(rest_context_t *rest, struct timeval *tv)
 {
     ulfius_req_t request;

--- a/examples/rest-server/rest-list.c
+++ b/examples/rest-server/rest-list.c
@@ -47,7 +47,26 @@ rest_list_t * rest_list_new(void)
     return list;
 }
 
-void rest_list_delete(rest_list_t *list);
+void rest_list_delete(rest_list_t *list)
+{
+    rest_list_entry_t *entry;
+
+    pthread_mutex_lock(&list->mutex);
+
+    while (list->head != NULL)
+    {
+        entry = list->head;
+        list->head = entry->next;
+        entry->next = NULL;
+        free(entry);
+    }
+
+    pthread_mutex_unlock(&list->mutex);
+
+    pthread_mutex_destroy(&list->mutex);
+
+    free(list);
+}
 
 void rest_list_add(rest_list_t *list, void *data)
 {

--- a/examples/rest-server/rest-notifications.c
+++ b/examples/rest-server/rest-notifications.c
@@ -225,7 +225,7 @@ json_t * rest_notifications_json(rest_context_t *rest)
         for (entry = rest->registrationList->head; entry != NULL; entry = entry->next)
         {
             reg = entry->data;
-            json_array_append(jarray, rest_registration_notification_to_json(reg));
+            json_array_append_new(jarray, rest_registration_notification_to_json(reg));
         }
         json_object_set_new(jnotifs, "registrations", jarray);
     }
@@ -236,7 +236,7 @@ json_t * rest_notifications_json(rest_context_t *rest)
         for (entry = rest->updateList->head; entry != NULL; entry = entry->next)
         {
             upd = entry->data;
-            json_array_append(jarray, rest_update_notification_to_json(upd));
+            json_array_append_new(jarray, rest_update_notification_to_json(upd));
         }
         json_object_set_new(jnotifs, "reg-updates", jarray);
     }
@@ -247,7 +247,7 @@ json_t * rest_notifications_json(rest_context_t *rest)
         for (entry = rest->deregistrationList->head; entry != NULL; entry = entry->next)
         {
             dereg = entry->data;
-            json_array_append(jarray, rest_deregistration_notification_to_json(dereg));
+            json_array_append_new(jarray, rest_deregistration_notification_to_json(dereg));
         }
         json_object_set_new(jnotifs, "de-registrations", jarray);
     }
@@ -258,7 +258,7 @@ json_t * rest_notifications_json(rest_context_t *rest)
         for (entry = rest->asyncResponseList->head; entry != NULL; entry = entry->next)
         {
             async = entry->data;
-            json_array_append(jarray, rest_async_response_to_json(async));
+            json_array_append_new(jarray, rest_async_response_to_json(async));
         }
         json_object_set_new(jnotifs, "async-responses", jarray);
     }

--- a/examples/rest-server/rest-resources.c
+++ b/examples/rest-server/rest-resources.c
@@ -36,6 +36,7 @@
 typedef struct
 {
     rest_context_t *rest;
+    uint8_t *payload;
     rest_async_response_t *response;
 } rest_async_context_t;
 
@@ -72,7 +73,12 @@ static void rest_async_cb(uint16_t clientID, lwm2m_uri_t *uriP, int status, lwm2
     rest_notify_async_response(ctx->rest, ctx->response);
 
     // Free rest_async_context_t which was allocated in rest_resources_read_cb
-    free(context);
+    if (ctx->payload != NULL)
+    {
+        free(ctx->payload);
+    }
+
+    free(ctx);
 }
 
 int rest_resources_rwe_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *context)
@@ -92,8 +98,6 @@ int rest_resources_rwe_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *co
     json_t *jresponse;
     rest_async_context_t *async_context = NULL;
     lwm2m_media_type_t format;
-    uint8_t *payload = NULL;
-    int length;
     int res;
 
     /*
@@ -184,6 +188,14 @@ int rest_resources_rwe_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *co
     }
 
     async_context->rest = rest;
+
+    async_context->payload = malloc(req->binary_body_length);
+    if (async_context->payload == NULL)
+    {
+        goto exit;
+    }
+    memcpy(async_context->payload, req->binary_body, req->binary_body_length);
+
     async_context->response = rest_async_response_new();
     if (async_context->response == NULL)
     {
@@ -205,35 +217,11 @@ int rest_resources_rwe_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *co
 
     case RES_ACTION_WRITE:
     case RES_ACTION_EXEC:
-#if 1
-        payload = malloc(req->binary_body_length);
-        if (payload == NULL)
-        {
-            goto exit;
-        }
-        length = req->binary_body_length;
-        memcpy(payload, req->binary_body, length);
-#else
-        // XXX: should content format be converted to TLV?
-        format = LWM2M_CONTENT_JSON;
-        size = lwm2m_data_parse(&uri, req->binary_body, req->binary_body_length, format, &data);
-        if (size < 1 || data == NULL)
-        {
-            goto exit;
-        }
-
-        format = LWM2M_CONTENT_TLV;
-        length = lwm2m_data_serialize(&uri, size, data, &format, &payload);
-        if (length < 1 || payload == NULL || format != LWM2M_CONTENT_TLV)
-        {
-            goto exit;
-        }
-#endif
         if (action == RES_ACTION_WRITE)
         {
             res = lwm2m_dm_write(
                     rest->lwm2m, client->internalID, &uri,
-                    format, payload, length,
+                    format, async_context->payload, req->binary_body_length,
                     rest_async_cb, async_context
             );
         }
@@ -241,7 +229,7 @@ int rest_resources_rwe_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *co
         {
             res = lwm2m_dm_execute(
                     rest->lwm2m, client->internalID, &uri,
-                    format, payload, length,
+                    format, async_context->payload, req->binary_body_length,
                     rest_async_cb, async_context
             );
         }
@@ -274,16 +262,17 @@ exit:
     {
         if (async_context != NULL)
         {
+            if (async_context->payload != NULL)
+            {
+                free(async_context->payload);
+            }
+
             if (async_context->response != NULL)
             {
                 free(async_context->response);
             }
-            free(async_context);
-        }
 
-        if (payload != NULL)
-        {
-            free(payload);
+            free(async_context);
         }
     }
 

--- a/examples/rest-server/restserver.c
+++ b/examples/rest-server/restserver.c
@@ -295,6 +295,9 @@ int main(int argc, char *argv[])
     ulfius_stop_framework(&instance);
     ulfius_clean_instance(&instance);
 
+    lwm2m_close(rest.lwm2m);
+    rest_cleanup(&rest);
+
     return 0;
 }
 

--- a/examples/rest-server/restserver.h
+++ b/examples/rest-server/restserver.h
@@ -84,6 +84,7 @@ int rest_notifications_pull_cb(const ulfius_req_t *req, ulfius_resp_t *resp, voi
 int rest_subscriptions_put_cb(const ulfius_req_t *req, ulfius_resp_t *resp, void *context);
 
 void rest_init(rest_context_t *rest);
+void rest_cleanup(rest_context_t *rest);
 int rest_step(rest_context_t *rest, struct timeval *tv);
 
 #endif // RESTSERVER_H


### PR DESCRIPTION
* JSON object leak in notifications channel
* CoAP transaction payload leak in resource write and execute
* Rest and lwm2m context cleanup on exit (sugar for valgrind)