### PR TITLE
lwm2m: do not finish request transaction on ACK

### DIFF
--- a/core/transaction.c
+++ b/core/transaction.c
@@ -126,6 +126,12 @@ static int prv_checkFinished(lwm2m_transaction_t * transacP,
         // response
         return transacP->ack_received ? 1 : 0;
     }
+
+    // Received message must be a response
+    if (receivedMessage->code < CREATED_2_01 - 1) {
+        return 0;
+    }
+
     if (!IS_OPTION(transactionMessage, COAP_OPTION_TOKEN))
     {
         // request without token


### PR DESCRIPTION
Currently lwm2m will call transaction completion callback when the ACK is received, however in the case where response is not piggybacked in the ACK, response code is not available (i.e. it is 0). This changes that the callback is called when the actual response arrives.