### PR TITLE
Signal pipe registration

### DIFF
--- a/examples/rest-server/restserver.c
+++ b/examples/rest-server/restserver.c
@@ -62,6 +62,7 @@ ignore_sigpipe ()
 {
   struct sigaction oldsig;
   struct sigaction sig;
+  memset(&sig, 0, sizeof(sig));
 
   sig.sa_handler = &catcher;
   sigemptyset (&sig.sa_mask);

--- a/examples/rest-server/restserver.c
+++ b/examples/rest-server/restserver.c
@@ -38,7 +38,6 @@
 static volatile int restserver_quit;
 static void sigint_handler(int signo)
 {
-    printf("Occurs SIGNAL no: %d\n",signo);
     restserver_quit = 1;
 }
 
@@ -331,14 +330,11 @@ int main(int argc, char *argv[])
         if (res < 0)
         {
             if (errno == EINTR) {
-                fprintf(stderr, "EINTR select() return: %d \n", res);
                 continue;
             }
 
             fprintf(stderr, "select() error: %d\n", res);
         }
-        else
-            fprintf(stderr, "select() return: %d\n", res);
 
         if (FD_ISSET(sock, &readfds))
         {

--- a/examples/shared/commandline.c
+++ b/examples/shared/commandline.c
@@ -190,7 +190,7 @@ void output_buffer(FILE * stream,
         int j;
 
         print_indent(stream, indent);
-        memcpy(array, buffer+i, ( i+16 > length ? length-i : 16) );//memcpy(array, buffer+i, 16);valgrind problem
+        memcpy(array, buffer+i, 16);
         for (j = 0 ; j < 16 && i+j < length; j++)
         {
             fprintf(stream, "%02X ", array[j]);

--- a/examples/shared/commandline.c
+++ b/examples/shared/commandline.c
@@ -190,7 +190,7 @@ void output_buffer(FILE * stream,
         int j;
 
         print_indent(stream, indent);
-        memcpy(array, buffer+i, 16);
+        memcpy(array, buffer+i, ( i+16 > length ? length-i : 16) );//memcpy(array, buffer+i, 16);valgrind problem
         for (j = 0 ; j < 16 && i+j < length; j++)
         {
             fprintf(stream, "%02X ", array[j]);


### PR DESCRIPTION
From example demo_https.c  server. Server can often crash without pipe signal ignore registration.
https://stackoverflow.com/questions/108183/how-to-prevent-sigpipes-or-handle-them-properly

Additional info from microhttp docs:
section SIGPIPE
cindex signals
MHD does not install a signal handler for SIGPIPE.  On platforms
where this is possible (such as GNU/Linux), it disables SIGPIPE for
its I/O operations (by passing MSG_NOSIGNAL).  On other platforms,
SIGPIPE signals may be generated from network operations by
MHD and will cause the process to die unless the developer
explicitly installs a signal handler for SIGPIPE.

**Hence portable code using MHD must install a SIGPIPE handler or
explicitly block the SIGPIPE signal.**  MHD does not do so in order
to avoid messing with other parts of the application that may
need to handle SIGPIPE in a particular way.  You can make your application handle SIGPIPE by calling the following function in main():

static void
catcher (int sig)
{
}

static void
ignore_sigpipe ()
{
  struct sigaction oldsig;
  struct sigaction sig;

  sig.sa_handler = &catcher;
  sigemptyset (&sig.sa_mask);
#ifdef SA_INTERRUPT
  sig.sa_flags = SA_INTERRUPT;  /* SunOS */
#else
  sig.sa_flags = SA_RESTART;
#endif
  if (0 != sigaction (SIGPIPE, &sig, &oldsig))
    fprintf (stderr,
             "Failed to install SIGPIPE handler: %s\n", strerror (errno));
}