### PR TITLE
core: remove client transactions when freeing it

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -268,6 +268,7 @@ lwm2m_transaction_t * transaction_new(void * sessionH, coap_method_t method, cha
 int transaction_send(lwm2m_context_t * contextP, lwm2m_transaction_t * transacP);
 void transaction_free(lwm2m_transaction_t * transacP);
 void transaction_remove(lwm2m_context_t * contextP, lwm2m_transaction_t * transacP);
+void transaction_remove_all(lwm2m_context_t * contextP, void * sessionH);
 bool transaction_handleResponse(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 void transaction_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 
@@ -287,7 +288,7 @@ lwm2m_observed_t * observe_findByUri(lwm2m_context_t * contextP, lwm2m_uri_t * u
 // defined in registration.c
 uint8_t registration_handleRequest(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 void registration_deregister(lwm2m_context_t * contextP, lwm2m_server_t * serverP);
-void registration_freeClient(lwm2m_client_t * clientP);
+void registration_freeClient(lwm2m_context_t * contextP, lwm2m_client_t * clientP);
 uint8_t registration_start(lwm2m_context_t * contextP);
 void registration_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 lwm2m_status_t registration_getStatus(lwm2m_context_t * contextP);

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -198,7 +198,7 @@ void lwm2m_close(lwm2m_context_t * contextP)
         clientP = contextP->clientList;
         contextP->clientList = contextP->clientList->next;
 
-        registration_freeClient(clientP);
+        registration_freeClient(contextP, clientP);
     }
 #endif
 

--- a/core/transaction.c
+++ b/core/transaction.c
@@ -268,6 +268,27 @@ void transaction_remove(lwm2m_context_t * contextP,
     transaction_free(transacP);
 }
 
+void transaction_remove_all(lwm2m_context_t * contextP,
+                            void * sessionH)
+{
+    lwm2m_transaction_t * transacP;
+    lwm2m_transaction_t * nextP;
+
+    transacP = contextP->transactionList;
+    while (transacP != NULL)
+    {
+        nextP = transacP->next;
+
+        if (lwm2m_session_is_equal(sessionH, transacP->peerH, contextP->userData) == true)
+        {
+            transaction_remove(contextP, transacP);
+
+        }
+
+        transacP = nextP;
+    }
+}
+
 bool transaction_handleResponse(lwm2m_context_t * contextP,
                                  void * fromSessionH,
                                  coap_packet_t * message,


### PR DESCRIPTION
Transactions have references to context that may be already dealloced
when the transaction completes (i.e. client is deregistered, but observation
transaction is pending and will time out).