### PR TITLE
[core] fix double memory free crash in observation

### DIFF
--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -503,6 +503,7 @@ typedef struct _lwm2m_observation_
     lwm2m_status_t          status;
     lwm2m_result_callback_t callback;
     void *                  userData;
+    uint32_t                pendingTransactions;
 } lwm2m_observation_t;
 
 /*


### PR DESCRIPTION
* lwm2m_observe_cancel instead of sending unobserve packet, now changes observation state
* lwm2m_observe_cancel calls callback immediately
* Number of pending transactions is tracked to prevent premature free